### PR TITLE
Break out qualifiers normalization subroutine as its own function

### DIFF
--- a/src/packageurl.py
+++ b/src/packageurl.py
@@ -65,6 +65,18 @@ def quote(s):
     return quoted.replace('%3A', ':')
 
 
+def get_quoter(encode=True):
+    """
+    Return quoting callable given an `encode` tri-boolean (True, False or None)
+    """
+    if encode is True:
+        return quote
+    elif encode is False:
+        return percent_unquote
+    elif encode is None:
+        return lambda x: x
+
+
 def normalize_qualifiers(qualifiers, encode=True):
     """
     Return normalized qualifiers.
@@ -75,12 +87,7 @@ def normalize_qualifiers(qualifiers, encode=True):
     If `qualifiers` is a string of qualfiers, formatted to the purl specifications, and `encode`
     is false, the string is then converted to a dictionary of qualifiers and their values.
     """
-    if encode is True:
-        quoting = quote
-    elif encode is False:
-        quoting = percent_unquote
-    elif encode is None:
-        quoting = lambda x: x
+    quoting = get_quoter(encode)
 
     if qualifiers:
         if isinstance(qualifiers, basestring):
@@ -111,26 +118,21 @@ def normalize_qualifiers(qualifiers, encode=True):
                 qualifiers = ['{}={}'.format(k, v) for k, v in qualifiers]
                 qualifiers = '&'.join(qualifiers)
 
-            return qualifiers
+            return qualifiers or None
 
 
 def normalize(type, namespace, name, version, qualifiers, subpath, encode=True):  # NOQA
     """
     Return normalized purl components.
     """
-    if encode is True:
-        quoting = quote
-    elif encode is False:
-        quoting = percent_unquote
-    elif encode is None:
-        quoting = lambda x: x
+    quoting = get_quoter(encode)
 
     if type:
         type = type.strip().lower()  # NOQA
 
     if namespace:
         namespace = namespace.strip().strip('/')
-        if type and type in ('bitbucket', 'github', 'pypi'):
+        if type in ('bitbucket', 'github', 'pypi'):
             namespace = namespace.lower()
         segments = namespace.split('/')
         segments = [seg for seg in segments if seg and seg.strip()]

--- a/test_purl.py
+++ b/test_purl.py
@@ -29,6 +29,7 @@ import json
 import re
 import unittest
 
+from packageurl import normalize_qualifiers
 from packageurl import PackageURL
 
 # Python 2 and 3 support
@@ -141,3 +142,31 @@ def build_tests(clazz=PurlTest, test_file='test-suite-data.json'):
 
 
 build_tests()
+
+
+class NormalizePurlQualifiersTest(unittest.TestCase):
+    canonical_purl = 'pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1?classifier=sources&repository_url=repo.spring.io/release'
+    type = 'maven'
+    namespace = 'org.apache.xmlgraphics'
+    name = 'batik-anim'
+    version = '1.9.1'
+    qualifiers_as_dict = {
+        'classifier': 'sources',
+        'repository_url': 'repo.spring.io/release'
+    }
+    qualifiers_as_string = 'classifier=sources&repository_url=repo.spring.io/release'
+    subpath = None
+
+    def test_normalize_qualifiers_as_string(self):
+        assert self.qualifiers_as_string == normalize_qualifiers(self.qualifiers_as_dict, encode=True)
+
+    def test_normalize_qualifiers_as_dict(self):
+        assert self.qualifiers_as_dict == normalize_qualifiers(self.qualifiers_as_string, encode=False)
+
+    def test_create_PackageURL_from_qualifiers_string(self):
+        assert self.canonical_purl == PackageURL(self.type, self.namespace, self.name, self.version,
+                                                    self.qualifiers_as_string, self.subpath).to_string()
+
+    def test_create_PackageURL_from_qualifiers_dict(self):
+        assert self.canonical_purl == PackageURL(self.type, self.namespace, self.name, self.version,
+                                                    self.qualifiers_as_dict, self.subpath).to_string()


### PR DESCRIPTION
By breaking out this functionality into its own function from `normalize()`, users can easily create a dictionary of qualifiers from a properly formatted string of qualifiers and vice versa.

Also, the PackageURL constructor has been changed to accept a string of qualifiers in addition to a dictionary of qualifiers.

Signed-off-by: Jono Yang <jyang@nexb.com>