### PR TITLE
Fix qualifiers string vs. dict nature

### DIFF
--- a/src/packageurl/contrib/django_models.py
+++ b/src/packageurl/contrib/django_models.py
@@ -112,12 +112,12 @@ class PackageURLMixin(models.Model):
 
     def set_package_url(self, package_url):
         """
-        Set values for each related field of the provided `package_url` string.
-        Empty/Null values are normalized to `None` and are set as well
-        to replace any existing values.
-        This prevent mixing newly provided values with old ones.
+        Set each field values to the values of the provided `package_url` string
+        or PackageURL object. Existing values are overwritten including setting
+        values to None for provided empty values.
         """
-        purl = PackageURL.from_string(package_url)
+        if not isinstance(package_url, PackageURL):
+            package_url = PackageURL.from_string(package_url)
 
-        for field_name, value in purl.to_dict().items():
+        for field_name, value in package_url.to_dict(encode=True).items():
             setattr(self, field_name, value or None)


### PR DESCRIPTION
This PR addresses some issues when serializing a PackageURL object to native types with the `to_dict()` method: the `qualifiers` were returned always as a regular, non-ordered mapping instead of a string.

With this PR, the signature has been update to `to_dict(encode=False)` . If `encode` is True, the qualifiers will be returned as a string and not a mapping.

If `encode` is False the mapping returned qualifiers is always an OrderedDict and not a plain dict().


The django_contrib model mixin has been updated accordingly.