### PR TITLE
README: Update links to point to travis.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,8 @@ Build and tests status
 +------------------------------------------------------------------------------------+
 |                         **Linux (Travis) on Python 2 and 3**                       |
 +====================================================================================+
-|.. image:: https://api.travis-ci.org/package-url/packageurl-python.png?branch=master|
-|   :target: https://travis-ci.org/package-url/packageurl-python                     |
+|.. image:: https://api.travis-ci.com/package-url/packageurl-python.png?branch=master|
+|   :target: https://travis-ci.com/package-url/packageurl-python                     |
 |   :alt: Linux Master branch tests status                                           |
 +------------------------------------------------------------------------------------+
 


### PR DESCRIPTION
travis.org is in the process of being consolidated into travis.com.