### PR TITLE
Make PackageURL type hashable

### DIFF
--- a/src/packageurl/__init__.py
+++ b/src/packageurl/__init__.py
@@ -282,6 +282,9 @@ class PackageURL(namedtuple('PackageURL', _components)):
     def __str__(self, *args, **kwargs):
         return self.to_string()
 
+    def __hash__(self):
+        return hash(self.to_string())
+
     def to_dict(self, encode=False):
         """
         Return an ordered dict of purl components as {key: value}. If `encode`

--- a/tests/test_packageurl.py
+++ b/tests/test_packageurl.py
@@ -286,3 +286,9 @@ class NormalizePurlTest(unittest.TestCase):
             ('subpath', u'this/is/a/path')
         ])
         assert expected == purl.to_dict(encode=True)
+
+
+def test_purl_is_hashable():
+    s = {PackageURL(name='hashable', type='pypi')}
+    assert len(s) == 1
+


### PR DESCRIPTION
Before this change it was not possible to store PackageURL instances in a set or other collection that calls `__hash__()`.

This change implements `__hash__()` as the hash of the string representation of the object.

Fixes #28