### PR TITLE
Increase version field length in PackageURLMixin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from setuptools import setup
 
 setup(
     name='packageurl-python',
-    version='0.8.7',
+    version='0.8.8',
     license='MIT',
     description='A "purl" aka. package URL parser and builder',
     long_description='Python library to parse and build "purl" aka. package URLs. '

--- a/src/packageurl/contrib/django_models.py
+++ b/src/packageurl/contrib/django_models.py
@@ -69,7 +69,7 @@ class PackageURLMixin(models.Model):
     )
 
     version = models.CharField(
-        max_length=50,
+        max_length=100,
         blank=True,
         null=True,
         help_text=_('Version of the package.'),

--- a/src/packageurl/contrib/django_models.py
+++ b/src/packageurl/contrib/django_models.py
@@ -124,6 +124,6 @@ class PackageURLMixin(models.Model):
             model_field = self._meta.get_field(field_name)
 
             if value and len(value) > model_field.max_length:
-                raise ValidationError(_(f'Value too long for field "{field_name}".'))
+                raise ValidationError(_('Value too long for field "{}".'.format(field_name)))
 
             setattr(self, field_name, value or None)


### PR DESCRIPTION
I have run into Package version strings that are longer than 50 chars, so I am increasing the version field length to 100 in PackageURLMixin.

Signed-off-by: Jono Yang <jyang@nexb.com>
