### PR TITLE
Use JSONField instead of CharField for storing qualifiers 

### DIFF
--- a/src/packageurl/contrib/django_models.py
+++ b/src/packageurl/contrib/django_models.py
@@ -31,7 +31,11 @@ from __future__ import unicode_literals
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
-from django.contrib.postgres.fields import JSONField
+try:
+    from models import JSONField
+except ImportError:
+    from django.contrib.postgres.fields import JSONField
+
 
 from packageurl import PackageURL
 
@@ -78,8 +82,7 @@ class PackageURLMixin(models.Model):
 
     # Use  models.JSONField once Django 3.1 is officially released
     qualifiers = JSONField(
-        max_length=1024,
-        blank=True,
+        default=dict,
         null=True,
         help_text=_(
             'Extra qualifying data for a package such as the name of an OS, '

--- a/src/packageurl/contrib/django_models.py
+++ b/src/packageurl/contrib/django_models.py
@@ -31,6 +31,7 @@ from __future__ import unicode_literals
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
+from django.contrib.postgres.fields import JSONField
 
 from packageurl import PackageURL
 
@@ -75,7 +76,8 @@ class PackageURLMixin(models.Model):
         help_text=_('Version of the package.'),
     )
 
-    qualifiers = models.CharField(
+    # Use  models.JSONField once Django 3.1 is officially released
+    qualifiers = JSONField(
         max_length=1024,
         blank=True,
         null=True,
@@ -120,7 +122,7 @@ class PackageURLMixin(models.Model):
         if not isinstance(package_url, PackageURL):
             package_url = PackageURL.from_string(package_url)
 
-        for field_name, value in package_url.to_dict(encode=True).items():
+        for field_name, value in package_url.to_dict().items():
             model_field = self._meta.get_field(field_name)
 
             if value and len(value) > model_field.max_length:


### PR DESCRIPTION
Using JSONField instead of CharField for storing qualifiers  has many advantages. 

The issues when using CharField are :  
Qualifiers are  stored as strings in the database, which implies that the order of each qualifier matters. This contradicts the Package URL specification(see https://github.com/package-url/purl-spec/issues/51#issuecomment-455563672 ) . Querying according to individual qualifier from the qualifier string is also not possible. 

These are rectified when using JSONField.


Signed-off-by: Shivam Sandbhor <shivam.sandbhor@gmail.com>