### PR TITLE
to_string() should properly encode '/' characters in the 'name' field…

### DIFF
--- a/src/packageurl/__init__.py
+++ b/src/packageurl/__init__.py
@@ -62,14 +62,14 @@ https://github.com/package-url/purl-spec
 """
 
 
-def quote(s):
+def quote(s, safe='/'):
     """
     Return a percent-encoded unicode string, except for colon :, given an `s`
     byte or unicode string.
     """
     if isinstance(s, unicode):
         s = s.encode('utf-8')
-    quoted = _percent_quote(s, safe='')
+    quoted = _percent_quote(s, safe=safe)
     if not isinstance(quoted, unicode):
         quoted = quoted.decode('utf-8')
     quoted = quoted.replace('%3A', ':')
@@ -131,7 +131,10 @@ def normalize_name(name, ptype, encode=True):  # NOQA
         name = name.decode('utf-8')
 
     quoter = get_quoter(encode)
-    name = quoter(name)
+    if encode:
+        name = quoter(name, safe='')
+    else:
+        name = quoter(name)
     name = name.strip().strip('/')
     if ptype in ('bitbucket', 'github', 'pypi',):
         name = name.lower()

--- a/src/packageurl/__init__.py
+++ b/src/packageurl/__init__.py
@@ -124,14 +124,14 @@ def normalize_namespace(namespace, ptype, encode=True):  # NOQA
     return '/'.join(segments) or None
 
 
-def normalize_name(name, ptype, encode=True):  # NOQA
+def normalize_name(name, ptype, encode=True, name_has_slash=False):  # NOQA
     if not name:
         return
     if not isinstance(name, unicode):
         name = name.decode('utf-8')
 
     quoter = get_quoter(encode)
-    if encode:
+    if encode and name_has_slash:
         name = quoter(name, safe='')
     else:
         name = quoter(name)
@@ -231,13 +231,13 @@ def normalize_subpath(subpath, encode=True):  # NOQA
     return subpath or None
 
 
-def normalize(type, namespace, name, version, qualifiers, subpath, encode=True):  # NOQA
+def normalize(type, namespace, name, version, qualifiers, subpath, encode=True, name_has_slash=False):  # NOQA
     """
     Return normalized purl components
     """
     type = normalize_type(type, encode)  # NOQA
     namespace = normalize_namespace(namespace, type, encode)
-    name = normalize_name(name, type, encode)
+    name = normalize_name(name, type, encode, name_has_slash=name_has_slash)
     version = normalize_version(version, encode)
     qualifiers = normalize_qualifiers(qualifiers, encode)
     subpath = normalize_subpath(subpath, encode)
@@ -254,7 +254,7 @@ class PackageURL(namedtuple('PackageURL', _components)):
     """
 
     def __new__(self, type=None, namespace=None, name=None,  # NOQA
-                version=None, qualifiers=None, subpath=None):
+                version=None, qualifiers=None, subpath=None, name_has_slash=False):
 
         required = dict(type=type, name=name)
         for key, value in required.items():
@@ -276,7 +276,7 @@ class PackageURL(namedtuple('PackageURL', _components)):
                              .format('qualifiers', repr(qualifiers)))
 
         type, namespace, name, version, qualifiers, subpath = normalize(# NOQA
-            type, namespace, name, version, qualifiers, subpath, encode=None)
+            type, namespace, name, version, qualifiers, subpath, encode=None, name_has_slash=name_has_slash)
 
         return super(PackageURL, self).__new__(PackageURL, type=type,
             namespace=namespace, name=name, version=version,

--- a/src/packageurl/__init__.py
+++ b/src/packageurl/__init__.py
@@ -69,6 +69,8 @@ def quote(s, safe='/'):
     """
     if isinstance(s, unicode):
         s = s.encode('utf-8')
+    if isinstance(safe, unicode):
+        safe = safe.encode('utf-8')
     quoted = _percent_quote(s, safe=safe)
     if not isinstance(quoted, unicode):
         quoted = quoted.decode('utf-8')
@@ -83,7 +85,7 @@ def unquote(s):
     """
     unquoted = _percent_unquote(s)
     if not isinstance(unquoted, unicode):
-        unquoted = unquoted .decode('utf-8')
+        unquoted = unquoted.decode('utf-8')
     return unquoted
 
 

--- a/src/packageurl/__init__.py
+++ b/src/packageurl/__init__.py
@@ -69,7 +69,7 @@ def quote(s):
     """
     if isinstance(s, unicode):
         s = s.encode('utf-8')
-    quoted = _percent_quote(s)
+    quoted = _percent_quote(s, safe='')
     if not isinstance(quoted, unicode):
         quoted = quoted.decode('utf-8')
     quoted = quoted.replace('%3A', ':')

--- a/tests/test_packageurl.py
+++ b/tests/test_packageurl.py
@@ -201,6 +201,24 @@ class NormalizePurlTest(unittest.TestCase):
                           qualifiers_as_dict, subpath)
         assert canonical_purl == purl.to_string()
 
+    def test_create_PackageURL_from_qualifiers_dict_with_name_has_slash(self):
+        type = 'generic' #NOQA
+        namespace = 'namespace.test'
+        name = 'Contains/Slash'
+        version = '1.2.3'
+        qualifiers_as_dict = {
+            'classifier': 'sources',
+            'repository_url': 'repo.test.io/release'
+        }
+        subpath = None
+
+        purl = PackageURL(type, namespace, name, version,
+                          qualifiers_as_dict, subpath, name_has_slash=True)
+        assert name == purl.name
+
+        purl_from_str = PackageURL.from_string(purl.to_string())
+        assert purl.to_string() == purl_from_str.to_string()
+
     def test_normalize_encode_can_take_unicode_with_non_ascii_with_slash(self):
         uncd = u'núcleo/núcleo'
         normal = normalize(


### PR DESCRIPTION
…. Else they get put in 'namespace' later.

This is SOMETIMES a desired behavior (or at least there are test cases assuming it works this way), but not always. This PR adds the option to pass `name_has_slash=True` internally in `normalize()` and `normalize_name()`, and externally in `PackageURL()` creation. It does NOT change default behavior when `name_has_slash=True` is omitted.


### Evidence
The slash doesn't get encoded when converting the purl to a string:
```
>>> name = "Name With/Slash"
>>> pkg_type = "generic"
>>> version = ""
>>> purl = PackageURL(name=name, type=pkg_type, version=version)
>>> purl
PackageURL(type='generic', namespace=None, name='Name With/Slash', version=None, qualifiers=OrderedDict(), subpath=None)
>>> purl.name
'Name With/Slash'
>>> str(purl)
'pkg:generic/Name%20With/Slash'
>>> purl.to_string()
'pkg:generic/Name%20With/Slash'
>>> purl2 = PackageURL.from_string(purl.to_string())
>>> purl2
PackageURL(type='generic', namespace='Name With', name='Slash', version=None, qualifiers=OrderedDict(), subpath=None)
```

### Digging into it
This happens in the `quote` function of `src/packageurl/__init__.py`.
```
try:
    # Python 2
    ...
    from urllib impose quote as _percent_quote
    ...
except ImportError:
    # Python 3
    ...
    from urllib.parse import quote as _percent_quote
    ...

...

def quote(s):
    ...
    quoted = _percent_quote(s)
    ...
```

From the urllib docs:
Python 3: https://docs.python.org/3/library/urllib.parse.html
```
urllib.parse.quote(string, safe='/', encoding=None, errors=None)
```
Python 2: https://docs.python.org/2/library/urllib.html
```
The optional safe parameter specifies additional characters that should not be quoted — its default value is '/'.
```