### PR TITLE
Remove the null=True on CharField fields of the PackageURLMixin #36

### DIFF
--- a/src/packageurl/__init__.py
+++ b/src/packageurl/__init__.py
@@ -298,7 +298,8 @@ class PackageURL(namedtuple('PackageURL', _components)):
                                                       encode=encode)
 
         if empty is not None:
-            data = OrderedDict((k, v or empty) for k, v in data.items())
+            for field, value in data.items():
+                data[field] = value or empty
 
         return data
 

--- a/src/packageurl/__init__.py
+++ b/src/packageurl/__init__.py
@@ -294,12 +294,10 @@ class PackageURL(namedtuple('PackageURL', _components)):
         """
         data = self._asdict()
         if encode:
-            data['qualifiers'] = normalize_qualifiers(self.qualifiers,
-                                                      encode=encode)
+            data['qualifiers'] = normalize_qualifiers(self.qualifiers, encode=encode)
 
-        if empty is not None:
-            for field, value in data.items():
-                data[field] = value or empty
+        for field, value in data.items():
+            data[field] = value or empty
 
         return data
 

--- a/src/packageurl/__init__.py
+++ b/src/packageurl/__init__.py
@@ -285,16 +285,21 @@ class PackageURL(namedtuple('PackageURL', _components)):
     def __hash__(self):
         return hash(self.to_string())
 
-    def to_dict(self, encode=False):
+    def to_dict(self, encode=False, empty=None):
         """
-        Return an ordered dict of purl components as {key: value}. If `encode`
-        is True, then "qualifiers" are encoded as a normalized string.
-        Otherwise, qualifiers is a mapping.
+        Return an ordered dict of purl components as {key: value}.
+        If `encode` is True, then "qualifiers" are encoded as a normalized
+        string. Otherwise, qualifiers is a mapping.
+        You can provide a value for `empty` to be used in place of default None.
         """
         data = self._asdict()
         if encode:
             data['qualifiers'] = normalize_qualifiers(self.qualifiers,
                                                       encode=encode)
+
+        if empty is not None:
+            data = OrderedDict((k, v or empty) for k, v in data.items())
+
         return data
 
     def to_string(self):

--- a/src/packageurl/contrib/django_models.py
+++ b/src/packageurl/contrib/django_models.py
@@ -30,7 +30,7 @@ from __future__ import unicode_literals
 
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from packageurl import PackageURL
 

--- a/tests/test_packageurl.py
+++ b/tests/test_packageurl.py
@@ -290,10 +290,22 @@ class NormalizePurlTest(unittest.TestCase):
     def test_to_dict_custom_empty_value(self):
         purl = PackageURL(
             type='maven',
+            namespace='',
             name='commons-logging',
             version='12.3',
             qualifiers=None,
         )
+
+        expected = OrderedDict([
+            ('type', 'maven'),
+            ('namespace', None),
+            ('name', 'commons-logging'),
+            ('version', '12.3'),
+            ('qualifiers', None),
+            ('subpath', None)
+        ])
+        assert expected == purl.to_dict()
+        assert expected == purl.to_dict(empty=None)
 
         expected = OrderedDict([
             ('type', 'maven'),
@@ -304,7 +316,6 @@ class NormalizePurlTest(unittest.TestCase):
             ('subpath', '')
         ])
         assert expected == purl.to_dict(empty='')
-        assert expected == purl.to_dict(encode=True, empty='')
 
 
 def test_purl_is_hashable():

--- a/tests/test_packageurl.py
+++ b/tests/test_packageurl.py
@@ -287,6 +287,25 @@ class NormalizePurlTest(unittest.TestCase):
         ])
         assert expected == purl.to_dict(encode=True)
 
+    def test_to_dict_custom_empty_value(self):
+        purl = PackageURL(
+            type='maven',
+            name='commons-logging',
+            version='12.3',
+            qualifiers=None,
+        )
+
+        expected = OrderedDict([
+            ('type', 'maven'),
+            ('namespace', ''),
+            ('name', 'commons-logging'),
+            ('version', '12.3'),
+            ('qualifiers', ''),
+            ('subpath', '')
+        ])
+        assert expected == purl.to_dict(empty='')
+        assert expected == purl.to_dict(encode=True, empty='')
+
 
 def test_purl_is_hashable():
     s = {PackageURL(name='hashable', type='pypi')}


### PR DESCRIPTION
From https://docs.djangoproject.com/en/3.0/ref/models/fields/#null

> Avoid using null on string-based fields such as CharField and TextField. If a string-based field has null=True, that means it has two possible values for “no data”: NULL, and the empty string. In most cases, it’s redundant to have two possible values for “no data;” the Django convention is to use the empty string, not NULL. 

This is an issue when adding database constraints based on those fields as '' and null values do not behave the same.

Add a `empty=None` param on the `PackageURL.to_dict` method to allow custom value like empty string '' in place of None

Signed-off-by: Thomas Druez <tdruez@nexb.com>