### PR TITLE
Bump version to 0.9.7

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-0.9.7 (2022-02-04)
+0.9.7 (2022-02-07)
 ------------------
 
 - Create a generic PackageURL for URLs that do not fit existing routes in url2purl #68

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = packageurl-python
-version = 0.9.6
+version = 0.9.7
 license = MIT
 description = A purl aka. Package URL parser and builder
 long_description = file:README.rst


### PR DESCRIPTION
  This PR bumps the version from 0.9.6 to 0.9.7 as well as updates the latest changelog entry date.