### PR TITLE
Update generic sourceforge purl generation in url2purl #79

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.9.8.1 (2022-02-11)
+------------------
+
+- Fix generic sourceforge PackageURL generation #79
+
 0.9.8 (2022-02-11)
 ------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = packageurl-python
-version = 0.9.8
+version = 0.9.8.1
 license = MIT
 description = A purl aka. Package URL parser and builder
 long_description = file:README.rst

--- a/src/packageurl/contrib/url2purl.py
+++ b/src/packageurl/contrib/url2purl.py
@@ -347,15 +347,17 @@ def build_sourceforge_purl(uri):
     if not sourceforge_purl:
         # Get the project name from `uri` and use that as the Package name
         # http://master.dl.sourceforge.net/project/aloyscore/aloyscore/0.1a1%2520stable/0.1a1_stable_AloysCore.zip
-        _, remaining_uri_path = uri.split('/project/') # http://master.dl.sourceforge.net, aloyscore/aloyscore/0.1a1%2520stable/0.1a1_stable_AloysCore.zip
-        if remaining_uri_path:
-            split_remaining_uri_path = remaining_uri_path.split('/') # aloyscore, aloyscore, 0.1a1%2520stable, 0.1a1_stable_AloysCore.zip
-            project_name = split_remaining_uri_path[0] # aloyscore
-            sourceforge_purl = PackageURL(
-                type='sourceforge',
-                name=project_name,
-                qualifiers={'download_url': uri}
-            )
+        split_uri = uri.split('/project/') # http://master.dl.sourceforge.net, aloyscore/aloyscore/0.1a1%2520stable/0.1a1_stable_AloysCore.zip
+        if len(split_uri) >= 2:
+            remaining_uri_path = split_uri[1] # aloyscore/aloyscore/0.1a1%2520stable/0.1a1_stable_AloysCore.zip
+            remaining_uri_path_segments = remaining_uri_path.split('/') # aloyscore, aloyscore, 0.1a1%2520stable, 0.1a1_stable_AloysCore.zip
+            if remaining_uri_path_segments:
+                project_name = remaining_uri_path_segments[0] # aloyscore
+                sourceforge_purl = PackageURL(
+                    type='sourceforge',
+                    name=project_name,
+                    qualifiers={'download_url': uri}
+                )
     return sourceforge_purl
 
 

--- a/tests/contrib/data/url2purl.json
+++ b/tests/contrib/data/url2purl.json
@@ -163,6 +163,7 @@
   "http://master.dl.sourceforge.net/project/tinyos/OldFiles/tinyos/1.1.0/tinyos-1.1.0.tar.gz": "pkg:sourceforge/tinyos?download_url=http://master.dl.sourceforge.net/project/tinyos/OldFiles/tinyos/1.1.0/tinyos-1.1.0.tar.gz",
   "http://master.dl.sourceforge.net/project/urlchecker/lu/ng/urlchecker/urlchecker/1.7/urlchecker-1.7-javadoc.jar": "pkg:sourceforge/urlchecker?download_url=http://master.dl.sourceforge.net/project/urlchecker/lu/ng/urlchecker/urlchecker/1.7/urlchecker-1.7-javadoc.jar",
   "http://master.dl.sourceforge.net/project/zclasspath/maven2/org/zclasspath/zclasspath/1.5/zclasspath-1.5.jar": "pkg:sourceforge/zclasspath?download_url=http://master.dl.sourceforge.net/project/zclasspath/maven2/org/zclasspath/zclasspath/1.5/zclasspath-1.5.jar",
+  "http://master.dl.sourceforge.net/project/googleimagedown/project/v1.1/GoogleImageDownloader-v1.1-src.tar.bz2": "pkg:sourceforge/googleimagedown?download_url=http://master.dl.sourceforge.net/project/googleimagedown/project/v1.1/GoogleImageDownloader-v1.1-src.tar.bz2",
   "https://crates.io/api/v1/crates/rand/0.7.2/download": "pkg:cargo/rand@0.7.2",
   "https://crates.io/api/v1/crates/clap/2.33.0/download": "pkg:cargo/clap@2.33.0",
   "https://crates.io/api/v1/crates/structopt/0.3.11/download": "pkg:cargo/structopt@0.3.11",


### PR DESCRIPTION
This PR fixes a bug in the generation of generic sourceforge PackageURLs, where there would be an exception thrown when `url2purl` encountered a sourceforge URL with multiple instances of the substring "project".