### PR TITLE
Bump version to v0.9.9 to be semver compliant

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,13 @@
 Changelog
 =========
 
-0.9.8.1 (2022-02-11)
+0.9.9 (2022-02-15)
 ------------------
+
+- Update version to be semver compliant. No changes to the code have been made.
+
+0.9.8.1 (2022-02-11)
+--------------------
 
 - Fix generic sourceforge PackageURL generation #79
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = packageurl-python
-version = 0.9.8.1
+version = 0.9.9
 license = MIT
 description = A purl aka. Package URL parser and builder
 long_description = file:README.rst


### PR DESCRIPTION
The version number of the latest release (0.9.8.1) is not semver compliant, so we are updating it to 0.9.9.