### PR TITLE
Support Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,29 @@ name: Python CI
 on: [push, pull_request]
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Python environment
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.6"
+          architecture: "x64"
+
+      - name: Install
+        run: |
+          pip install -e .[lint]
+
+      - name: Validate
+        run: |
+          isort --check-only src/ tests/
+          black --check --line-length 100 .
+
   build-and-test:
     name: Test & build (py${{ matrix.python-version }} on ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -23,7 +46,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Python environment
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           architecture: "x64"
@@ -32,11 +55,6 @@ jobs:
         run: |
           pip install -e .[test]
           pip install -e .[build]
-
-      - name: Validate
-        run: |
-          isort --check-only src/ tests/
-          black --check --line-length 100 .
 
       - name: Test
         run: py.test -vvs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version:
+          - "3.11-dev"
           - "3.10"
           - "3.9"
           - "3.8"

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Software Development :: Libraries
     Topic :: Utilities
 keywords =

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,10 +45,11 @@ install_requires =
 where = src
 
 [options.extras_require]
-test =
-    pytest
+lint =
     isort
     black
+test =
+    pytest
 build =
     wheel
 


### PR DESCRIPTION
- added support for Python 3.11, there was nothing special to do like deprecation warnings
- moved linting to a dedicated GHA job, so it will be run only on ubuntu with Python 3.6, there is no need to run it on 3 OS x 6  Python versions
- updated `setup-python` action to v4, no relevant change for this project to be aware of