### PR TITLE
url2purl: handle github release tags

### DIFF
--- a/src/packageurl/contrib/url2purl.py
+++ b/src/packageurl/contrib/url2purl.py
@@ -465,7 +465,7 @@ def build_github_purl(url):
 
     releases_tag_pattern = (
         r"https?://github.com/(?P<namespace>.+)/(?P<name>.+)"
-        r"/releases/tag/(?P<version_prefix>v|V?)(?P<version>[^/]+)/?.*$"
+        r"/releases/tag/(?P<version_prefix>v|V?)(?P<version>[\w\.\-\/@]+)(?<!\/)(\/*)$"
     )
 
     # https://github.com/pombredanne/schematics.git
@@ -482,6 +482,7 @@ def build_github_purl(url):
     )
 
     for pattern in patterns:
+        url = unquote_plus(url)
         matches = re.search(pattern, url)
         qualifiers = {}
         if matches:

--- a/src/packageurl/contrib/url2purl.py
+++ b/src/packageurl/contrib/url2purl.py
@@ -463,6 +463,11 @@ def build_github_purl(url):
         r"/releases/download/(?P<version_prefix>v|V?)(?P<version>[^/]+)/.*$"
     )
 
+    releases_tag_pattern = (
+        r"https?://github.com/(?P<namespace>.+)/(?P<name>.+)"
+        r"/releases/tag/(?P<version_prefix>v|V?)(?P<version>[^/]+)/?.*$"
+    )
+
     # https://github.com/pombredanne/schematics.git
     git_pattern = r"https?://github.com/(?P<namespace>.+)/(?P<name>.+).(git)"
 
@@ -471,6 +476,7 @@ def build_github_purl(url):
         raw_pattern,
         blob_pattern,
         releases_download_pattern,
+        releases_tag_pattern,
         download_pattern,
         git_pattern,
     )

--- a/tests/contrib/data/url2purl.json
+++ b/tests/contrib/data/url2purl.json
@@ -227,6 +227,8 @@
   "https://github.com/apache/cordova-osx/archive/rel/4.0.0.zip": "pkg:github/apache/cordova-osx@4.0.0",
   "https://github.com/sehmaschine/django-grappelli/archive/stable/2.13.x.zip": "pkg:github/sehmaschine/django-grappelli@2.13.x",
   "https://github.com/package-url/packageurl-python/releases/tag/v0.11.1": "pkg:github/package-url/packageurl-python@0.11.1?version_prefix=v",
+  "https://github.com/n1ru4l/envelop/releases/tag/%40envelop%2Fcore%402.3.3": "pkg:github/n1ru4l/envelop@%40envelop/core%402.3.3",
+  "https://github.com/n1ru4l/envelop/releases/tag/@envelop/core@2.3.3": "pkg:github/n1ru4l/envelop@%40envelop/core%402.3.3",
   "https://bitbucket.org/TG1999/first_repo/src/qa/": "pkg:bitbucket/tg1999/first_repo@qa",
   "https://bitbucket.org/TG1999/first_repo/src/QA/": "pkg:bitbucket/tg1999/first_repo@QA",
   "https://bitbucket.org/TG1999/first_repo/": "pkg:bitbucket/tg1999/first_repo",

--- a/tests/contrib/data/url2purl.json
+++ b/tests/contrib/data/url2purl.json
@@ -228,6 +228,7 @@
   "https://github.com/sehmaschine/django-grappelli/archive/stable/2.13.x.zip": "pkg:github/sehmaschine/django-grappelli@2.13.x",
   "https://github.com/package-url/packageurl-python/releases/tag/v0.11.1": "pkg:github/package-url/packageurl-python@0.11.1?version_prefix=v",
   "https://github.com/n1ru4l/envelop/releases/tag/%40envelop%2Fcore%402.3.3": "pkg:github/n1ru4l/envelop@%40envelop/core%402.3.3",
+  "https://github.com/n1ru4l/envelop/releases/tag/%40envelop%2Fcore%402.3.3////": "pkg:github/n1ru4l/envelop@%40envelop/core%402.3.3",
   "https://github.com/n1ru4l/envelop/releases/tag/@envelop/core@2.3.3": "pkg:github/n1ru4l/envelop@%40envelop/core%402.3.3",
   "https://bitbucket.org/TG1999/first_repo/src/qa/": "pkg:bitbucket/tg1999/first_repo@qa",
   "https://bitbucket.org/TG1999/first_repo/src/QA/": "pkg:bitbucket/tg1999/first_repo@QA",

--- a/tests/contrib/data/url2purl.json
+++ b/tests/contrib/data/url2purl.json
@@ -226,6 +226,7 @@
   "https://github.com/renozao/NMF/archive/hotfix/0.20.1.zip": "pkg:github/renozao/nmf@0.20.1",
   "https://github.com/apache/cordova-osx/archive/rel/4.0.0.zip": "pkg:github/apache/cordova-osx@4.0.0",
   "https://github.com/sehmaschine/django-grappelli/archive/stable/2.13.x.zip": "pkg:github/sehmaschine/django-grappelli@2.13.x",
+  "https://github.com/package-url/packageurl-python/releases/tag/v0.11.1": "pkg:github/package-url/packageurl-python@0.11.1?version_prefix=v",
   "https://bitbucket.org/TG1999/first_repo/src/qa/": "pkg:bitbucket/tg1999/first_repo@qa",
   "https://bitbucket.org/TG1999/first_repo/src/QA/": "pkg:bitbucket/tg1999/first_repo@QA",
   "https://bitbucket.org/TG1999/first_repo/": "pkg:bitbucket/tg1999/first_repo",


### PR DESCRIPTION
Some tools are reporting `https://github.com/<namespace>/<name>/releases/tag/<version>` urls for github packages, let's make sure we can generate proper purls.

**Input:** `https://github.com/package-url/packageurl-python/releases/tag/v0.11.1`
**Before:** pkg:github/package-url/packageurl-python@releases#tag/v0.11.1
**After:** pkg:github/package-url/packageurl-python@0.11.1?version_prefix=v