### PR TITLE
url2purl: add cran ecosystem

### DIFF
--- a/src/packageurl/contrib/purl2url.py
+++ b/src/packageurl/contrib/purl2url.py
@@ -185,6 +185,7 @@ def build_rubygems_repo_url(purl):
     elif name:
         return f"https://rubygems.org/gems/{name}"
 
+
 @repo_router.route("pkg:cran/.*")
 def build_cran_repo_url(purl):
     """

--- a/src/packageurl/contrib/purl2url.py
+++ b/src/packageurl/contrib/purl2url.py
@@ -185,6 +185,18 @@ def build_rubygems_repo_url(purl):
     elif name:
         return f"https://rubygems.org/gems/{name}"
 
+@repo_router.route("pkg:cran/.*")
+def build_cran_repo_url(purl):
+    """
+    Return a cran repo URL from the `purl` string.
+    """
+    purl_data = PackageURL.from_string(purl)
+
+    name = purl_data.name
+    version = purl_data.version
+
+    return f"https://cran.r-project.org/src/contrib/{name}_{version}.tar.gz"
+
 
 @repo_router.route("pkg:npm/.*")
 def build_npm_repo_url(purl):

--- a/src/packageurl/contrib/url2purl.py
+++ b/src/packageurl/contrib/url2purl.py
@@ -284,9 +284,7 @@ def build_rubygems_purl(uri):
     "https?://packagemanager.rstudio.com/cran/.*",
 )
 def build_cran_purl(uri):
-    cran_pattern = (
-        r"^https?://(cran\.r-project\.org|packagemanager\.rstudio\.com/cran)/.*?src/contrib/(?P<name>.+)_(?P<version>.+)\.tar.gz$"
-    )
+    cran_pattern = r"^https?://(cran\.r-project\.org|packagemanager\.rstudio\.com/cran)/.*?src/contrib/(?P<name>.+)_(?P<version>.+)\.tar.gz$"
     qualifiers = {}
     if "//cran.r-project.org/" not in uri:
         qualifiers["download_url"] = uri

--- a/src/packageurl/contrib/url2purl.py
+++ b/src/packageurl/contrib/url2purl.py
@@ -277,6 +277,22 @@ def build_rubygems_purl(uri):
     return purl_from_pattern("gem", rubygems_pattern, uri)
 
 
+# https://cran.r-project.org/src/contrib/jsonlite_1.8.8.tar.gz
+# https://packagemanager.rstudio.com/cran/2022-06-23/src/contrib/curl_4.3.2.tar.gz"
+@purl_router.route(
+    "https?://cran.r-project.org/.*",
+    "https?://packagemanager.rstudio.com/cran/.*",
+)
+def build_cran_purl(uri):
+    cran_pattern = (
+        r"^https?://(cran\.r-project\.org|packagemanager\.rstudio\.com/cran)/.*?src/contrib/(?P<name>.+)_(?P<version>.+)\.tar.gz$"
+    )
+    qualifiers = {}
+    if "//cran.r-project.org/" not in uri:
+        qualifiers["download_url"] = uri
+    return purl_from_pattern("cran", cran_pattern, uri, qualifiers)
+
+
 # https://pypi.org/packages/source/a/anyjson/anyjson-0.3.3.tar.gz
 # https://pypi.python.org/packages/source/a/anyjson/anyjson-0.3.3.tar.gz
 # https://pypi.python.org/packages/2.6/t/threadpool/threadpool-1.2.7-py2.6.egg

--- a/tests/contrib/data/url2purl.json
+++ b/tests/contrib/data/url2purl.json
@@ -267,5 +267,7 @@
   "https://salsa.debian.org/lxc-team/lxc/-/archive/master/lxc-master.tar.gz": "pkg:generic/lxc-master.tar.gz?download_url=https://salsa.debian.org/lxc-team/lxc/-/archive/master/lxc-master.tar.gz",
   "http://apt-rpm.org/": null,
   "": null,
-  "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/android-notifier/android-notifier-desktop-0.5.1-1.i386.rpm": "pkg:generic/code.google.com/android-notifier?download_url=https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/android-notifier/android-notifier-desktop-0.5.1-1.i386.rpm"
+  "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/android-notifier/android-notifier-desktop-0.5.1-1.i386.rpm": "pkg:generic/code.google.com/android-notifier?download_url=https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/android-notifier/android-notifier-desktop-0.5.1-1.i386.rpm",
+  "https://cran.r-project.org/src/contrib/jsonlite_1.8.8.tar.gz": "pkg:cran/jsonlite@1.8.8",
+  "https://packagemanager.rstudio.com/cran/2022-06-23/src/contrib/curl_4.3.2.tar.gz": "pkg:cran/curl@4.3.2?download_url=https://packagemanager.rstudio.com/cran/2022-06-23/src/contrib/curl_4.3.2.tar.gz"
 }


### PR DESCRIPTION
As defined here: https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#cran Make sure we handle urls from both cran and rstduio.

Test plan: added unit tests