### PR TITLE
Add repo URL support and testing for cocoapods

### DIFF
--- a/src/packageurl/contrib/purl2url.py
+++ b/src/packageurl/contrib/purl2url.py
@@ -21,9 +21,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# Visit https://github.com/package-url/packageurl-python for support and
-# download.
-
 
 from packageurl import PackageURL
 from packageurl.contrib.route import NoRouteAvailable
@@ -76,12 +73,7 @@ def get_download_url(purl):
         return download_url
 
     # Fallback on the `download_url` qualifier when available.
-    purl_data = None
-    try:
-        purl_data = PackageURL.from_string(purl)
-    except Exception as e:
-        print(f"An error occurred in get_download_url(): {e}")
-        return
+    purl_data = PackageURL.from_string(purl)
     return purl_data.qualifiers.get("download_url", None)
 
 
@@ -315,18 +307,9 @@ def build_cocoapods_repo_url(purl):
     """
     Return a CocoaPods repo URL from the `purl` string.
     """
-    purl_data = None
-    name = None
-    try:
-        purl_data = PackageURL.from_string(purl)
-        name = purl_data.name
-    except Exception as e:
-        print(f"An error occurred in build_cocoapods_repo_url(): {e}")
-        return
-
-    if not name:
-        return
-    return f"https://cocoapods.org/pods/{name}"
+    purl_data = PackageURL.from_string(purl)
+    name = purl_data.name
+    return name and f"https://cocoapods.org/pods/{name}"
 
 
 # Download URLs:

--- a/src/packageurl/contrib/purl2url.py
+++ b/src/packageurl/contrib/purl2url.py
@@ -304,6 +304,20 @@ def build_golang_repo_url(purl):
         return f"https://pkg.go.dev/{namespace}/{name}"
 
 
+@repo_router.route("pkg:cocoapods/.*")
+def build_cocoapods_repo_url(purl):
+    """
+    Return a CocoaPods repo URL from the `purl` string.
+    """
+    purl_data = PackageURL.from_string(purl)
+    name = purl_data.name
+
+    if name:
+        repository_homepage_url = f"https://cocoapods.org/pods/{name}"
+
+    return repository_homepage_url
+
+
 # Download URLs:
 
 

--- a/src/packageurl/contrib/purl2url.py
+++ b/src/packageurl/contrib/purl2url.py
@@ -21,6 +21,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+# Visit https://github.com/package-url/packageurl-python for support and
+# download.
 
 from packageurl import PackageURL
 from packageurl.contrib.route import NoRouteAvailable

--- a/src/packageurl/contrib/purl2url.py
+++ b/src/packageurl/contrib/purl2url.py
@@ -24,6 +24,7 @@
 # Visit https://github.com/package-url/packageurl-python for support and
 # download.
 
+
 from packageurl import PackageURL
 from packageurl.contrib.route import NoRouteAvailable
 from packageurl.contrib.route import Router
@@ -75,7 +76,12 @@ def get_download_url(purl):
         return download_url
 
     # Fallback on the `download_url` qualifier when available.
-    purl_data = PackageURL.from_string(purl)
+    purl_data = None
+    try:
+        purl_data = PackageURL.from_string(purl)
+    except Exception as e:
+        print(f"An error occurred in get_download_url(): {e}")
+        return
     return purl_data.qualifiers.get("download_url", None)
 
 
@@ -309,13 +315,18 @@ def build_cocoapods_repo_url(purl):
     """
     Return a CocoaPods repo URL from the `purl` string.
     """
-    purl_data = PackageURL.from_string(purl)
-    name = purl_data.name
+    purl_data = None
+    name = None
+    try:
+        purl_data = PackageURL.from_string(purl)
+        name = purl_data.name
+    except Exception as e:
+        print(f"An error occurred in build_cocoapods_repo_url(): {e}")
+        return
 
-    if name:
-        repository_homepage_url = f"https://cocoapods.org/pods/{name}"
-
-    return repository_homepage_url
+    if not name:
+        return
+    return f"https://cocoapods.org/pods/{name}"
 
 
 # Download URLs:

--- a/tests/contrib/test_purl2url.py
+++ b/tests/contrib/test_purl2url.py
@@ -136,9 +136,7 @@ def test_purl2url_get_inferred_urls():
             "https://gitlab.com/tg1999/firebase",
             "https://gitlab.com/tg1999/firebase/-/archive/1a122122/firebase-1a122122.tar.gz",
         ],
-        "pkg:pypi/sortedcontainers@2.4.0": [
-            "https://pypi.org/project/sortedcontainers/2.4.0/"
-        ],
+        "pkg:pypi/sortedcontainers@2.4.0": ["https://pypi.org/project/sortedcontainers/2.4.0/"],
         "pkg:cocoapods/AFNetworking@4.0.1": ["https://cocoapods.org/pods/AFNetworking"],
         "pkg:composer/psr/log@1.1.3": ["https://packagist.org/packages/psr/log#1.1.3"],
         "pkg:rubygems/package-name": ["https://rubygems.org/gems/package-name"],

--- a/tests/contrib/test_purl2url.py
+++ b/tests/contrib/test_purl2url.py
@@ -21,8 +21,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# Visit https://github.com/package-url/packageurl-python for support and
-# download.
 
 import pytest
 
@@ -66,7 +64,6 @@ def test_purl2url_get_repo_url():
         "pkg:golang/gopkg.in/ldap.v3@v3.1.0": "https://pkg.go.dev/gopkg.in/ldap.v3@v3.1.0",
         "pkg:cocoapods/AFNetworking@4.0.1": "https://cocoapods.org/pods/AFNetworking",
         "pkg:cocoapods/MapsIndoors@3.24.0": "https://cocoapods.org/pods/MapsIndoors",
-        "pkg:cocoapods/": None,
     }
 
     for purl, url in purls_url.items():
@@ -141,7 +138,6 @@ def test_purl2url_get_inferred_urls():
             "https://pypi.org/project/sortedcontainers/2.4.0/"
         ],
         "pkg:cocoapods/AFNetworking@4.0.1": ["https://cocoapods.org/pods/AFNetworking"],
-        "pkg:cocoapods/": [],
         "pkg:composer/psr/log@1.1.3": ["https://packagist.org/packages/psr/log#1.1.3"],
         "pkg:rubygems/package-name": ["https://rubygems.org/gems/package-name"],
         "pkg:bitbucket/birkenfeld": [],

--- a/tests/contrib/test_purl2url.py
+++ b/tests/contrib/test_purl2url.py
@@ -21,6 +21,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+# Visit https://github.com/package-url/packageurl-python for support and
+# download.
 
 import pytest
 

--- a/tests/contrib/test_purl2url.py
+++ b/tests/contrib/test_purl2url.py
@@ -64,6 +64,8 @@ def test_purl2url_get_repo_url():
         "pkg:golang/xorm.io/xorm": "https://pkg.go.dev/xorm.io/xorm",
         "pkg:golang/xorm.io/xorm@v0.8.2": "https://pkg.go.dev/xorm.io/xorm@v0.8.2",
         "pkg:golang/gopkg.in/ldap.v3@v3.1.0": "https://pkg.go.dev/gopkg.in/ldap.v3@v3.1.0",
+        "pkg:cocoapods/AFNetworking@4.0.1": "https://cocoapods.org/pods/AFNetworking",
+        "pkg:cocoapods/MapsIndoors@3.24.0": "https://cocoapods.org/pods/MapsIndoors",
     }
 
     for purl, url in purls_url.items():
@@ -134,7 +136,10 @@ def test_purl2url_get_inferred_urls():
             "https://gitlab.com/tg1999/firebase",
             "https://gitlab.com/tg1999/firebase/-/archive/1a122122/firebase-1a122122.tar.gz",
         ],
-        "pkg:pypi/sortedcontainers@2.4.0": ["https://pypi.org/project/sortedcontainers/2.4.0/"],
+        "pkg:pypi/sortedcontainers@2.4.0": [
+            "https://pypi.org/project/sortedcontainers/2.4.0/"
+        ],
+        "pkg:cocoapods/AFNetworking@4.0.1": ["https://cocoapods.org/pods/AFNetworking"],
         "pkg:composer/psr/log@1.1.3": ["https://packagist.org/packages/psr/log#1.1.3"],
         "pkg:rubygems/package-name": ["https://rubygems.org/gems/package-name"],
         "pkg:bitbucket/birkenfeld": [],

--- a/tests/contrib/test_purl2url.py
+++ b/tests/contrib/test_purl2url.py
@@ -66,6 +66,7 @@ def test_purl2url_get_repo_url():
         "pkg:golang/gopkg.in/ldap.v3@v3.1.0": "https://pkg.go.dev/gopkg.in/ldap.v3@v3.1.0",
         "pkg:cocoapods/AFNetworking@4.0.1": "https://cocoapods.org/pods/AFNetworking",
         "pkg:cocoapods/MapsIndoors@3.24.0": "https://cocoapods.org/pods/MapsIndoors",
+        "pkg:cocoapods/": None,
     }
 
     for purl, url in purls_url.items():
@@ -140,6 +141,7 @@ def test_purl2url_get_inferred_urls():
             "https://pypi.org/project/sortedcontainers/2.4.0/"
         ],
         "pkg:cocoapods/AFNetworking@4.0.1": ["https://cocoapods.org/pods/AFNetworking"],
+        "pkg:cocoapods/": [],
         "pkg:composer/psr/log@1.1.3": ["https://packagist.org/packages/psr/log#1.1.3"],
         "pkg:rubygems/package-name": ["https://rubygems.org/gems/package-name"],
         "pkg:bitbucket/birkenfeld": [],


### PR DESCRIPTION
Reference: https://github.com/package-url/packageurl-python/issues/143

@TG1999   This replaces the recently-closed [PR 151](https://github.com/package-url/packageurl-python/pull/151).  I look forward to your comments and questions.