### PR TITLE
feat: fix parsing of names and namespaces with colons

### DIFF
--- a/src/packageurl/__init__.py
+++ b/src/packageurl/__init__.py
@@ -77,11 +77,13 @@ def unquote(s: AnyStr) -> str:
 
 
 @overload
-def get_quoter(encode: bool = True) -> Callable[[AnyStr], str]: ...
+def get_quoter(encode: bool = True) -> Callable[[AnyStr], str]:
+    ...
 
 
 @overload
-def get_quoter(encode: None) -> Callable[[str], str]: ...
+def get_quoter(encode: None) -> Callable[[str], str]:
+    ...
 
 
 def get_quoter(encode: bool | None = True) -> Callable[[AnyStr], str] | Callable[[str], str]:
@@ -151,19 +153,22 @@ def normalize_version(version: AnyStr | None, encode: bool | None = True) -> str
 @overload
 def normalize_qualifiers(
     qualifiers: AnyStr | dict[str, str] | None, encode: Literal[True] = ...
-) -> str | None: ...
+) -> str | None:
+    ...
 
 
 @overload
 def normalize_qualifiers(
     qualifiers: AnyStr | dict[str, str] | None, encode: Literal[False] | None
-) -> dict[str, str]: ...
+) -> dict[str, str]:
+    ...
 
 
 @overload
 def normalize_qualifiers(
     qualifiers: AnyStr | dict[str, str] | None, encode: bool | None = ...
-) -> str | dict[str, str] | None: ...
+) -> str | dict[str, str] | None:
+    ...
 
 
 def normalize_qualifiers(
@@ -251,7 +256,8 @@ def normalize(
     qualifiers: AnyStr | dict[str, str] | None,
     subpath: AnyStr | None,
     encode: Literal[True] = ...,
-) -> tuple[str, str | None, str, str | None, str | None, str | None]: ...
+) -> tuple[str, str | None, str, str | None, str | None, str | None]:
+    ...
 
 
 @overload
@@ -263,7 +269,8 @@ def normalize(
     qualifiers: AnyStr | dict[str, str] | None,
     subpath: AnyStr | None,
     encode: Literal[False] | None,
-) -> tuple[str, str | None, str, str | None, dict[str, str], str | None]: ...
+) -> tuple[str, str | None, str, str | None, dict[str, str], str | None]:
+    ...
 
 
 @overload
@@ -275,7 +282,8 @@ def normalize(
     qualifiers: AnyStr | dict[str, str] | None,
     subpath: AnyStr | None,
     encode: bool | None = ...,
-) -> tuple[str, str | None, str, str | None, str | dict[str, str] | None, str | None]: ...
+) -> tuple[str, str | None, str, str | None, str | dict[str, str] | None, str | None]:
+    ...
 
 
 def normalize(
@@ -459,12 +467,17 @@ class PackageURL(
             url=remainder, scheme="", allow_fragments=True
         )
 
-        if scheme or authority:
-            msg = (
-                f'Invalid purl {purl!r} cannot contain a "user:pass@host:port" '
-                f"URL Authority component: {authority!r}."
-            )
-            raise ValueError(msg)
+        # The spec (seems) to allow colons in the name and namespace.
+        # urllib.urlsplit splits on : considers them parts of scheme
+        # and authority.
+        # Other libraries do not care about this.
+        # See https://github.com/package-url/packageurl-python/issues/152#issuecomment-2637692538
+        # We do + ":" + to put the colon back that urlsplit removed.
+        if authority:
+            path = authority + ":" + path
+
+        if scheme:
+            path = scheme + ":" + path
 
         path = path.lstrip("/")
 

--- a/src/packageurl/__init__.py
+++ b/src/packageurl/__init__.py
@@ -77,13 +77,11 @@ def unquote(s: AnyStr) -> str:
 
 
 @overload
-def get_quoter(encode: bool = True) -> Callable[[AnyStr], str]:
-    ...
+def get_quoter(encode: bool = True) -> Callable[[AnyStr], str]: ...
 
 
 @overload
-def get_quoter(encode: None) -> Callable[[str], str]:
-    ...
+def get_quoter(encode: None) -> Callable[[str], str]: ...
 
 
 def get_quoter(encode: bool | None = True) -> Callable[[AnyStr], str] | Callable[[str], str]:
@@ -153,22 +151,19 @@ def normalize_version(version: AnyStr | None, encode: bool | None = True) -> str
 @overload
 def normalize_qualifiers(
     qualifiers: AnyStr | dict[str, str] | None, encode: Literal[True] = ...
-) -> str | None:
-    ...
+) -> str | None: ...
 
 
 @overload
 def normalize_qualifiers(
     qualifiers: AnyStr | dict[str, str] | None, encode: Literal[False] | None
-) -> dict[str, str]:
-    ...
+) -> dict[str, str]: ...
 
 
 @overload
 def normalize_qualifiers(
     qualifiers: AnyStr | dict[str, str] | None, encode: bool | None = ...
-) -> str | dict[str, str] | None:
-    ...
+) -> str | dict[str, str] | None: ...
 
 
 def normalize_qualifiers(
@@ -256,8 +251,7 @@ def normalize(
     qualifiers: AnyStr | dict[str, str] | None,
     subpath: AnyStr | None,
     encode: Literal[True] = ...,
-) -> tuple[str, str | None, str, str | None, str | None, str | None]:
-    ...
+) -> tuple[str, str | None, str, str | None, str | None, str | None]: ...
 
 
 @overload
@@ -269,8 +263,7 @@ def normalize(
     qualifiers: AnyStr | dict[str, str] | None,
     subpath: AnyStr | None,
     encode: Literal[False] | None,
-) -> tuple[str, str | None, str, str | None, dict[str, str], str | None]:
-    ...
+) -> tuple[str, str | None, str, str | None, dict[str, str], str | None]: ...
 
 
 @overload
@@ -282,8 +275,7 @@ def normalize(
     qualifiers: AnyStr | dict[str, str] | None,
     subpath: AnyStr | None,
     encode: bool | None = ...,
-) -> tuple[str, str | None, str, str | None, str | dict[str, str] | None, str | None]:
-    ...
+) -> tuple[str, str | None, str, str | None, str | dict[str, str] | None, str | None]: ...
 
 
 def normalize(

--- a/tests/test_packageurl.py
+++ b/tests/test_packageurl.py
@@ -342,7 +342,7 @@ def test_colons_in_name_are_handled_correctly() -> None:
     assert p.name == "libiconv: character set conversion library"
     assert p.version == "1.9"
     assert p.qualifiers == {"package-id": "e11a609df352e292"}
-    assert p.subpath == None
+    assert p.subpath is None
 
     assert PackageURL.from_string(p.to_string()).to_string() == p.to_string()
 
@@ -357,7 +357,7 @@ def test_colons_in_namespace_are_handled_correctly() -> None:
     assert p.name == "libiconv: character set conversion library"
     assert p.version == "1.9"
     assert p.qualifiers == {"package-id": "e11a609df352e292"}
-    assert p.subpath == None
+    assert p.subpath is None
 
     assert PackageURL.from_string(p.to_string()).to_string() == p.to_string()
 

--- a/tests/test_packageurl.py
+++ b/tests/test_packageurl.py
@@ -330,3 +330,47 @@ class NormalizePurlTest(unittest.TestCase):
 def test_purl_is_hashable():
     s = {PackageURL(name="hashable", type="pypi")}
     assert len(s) == 1
+
+
+def test_colons_in_name_are_handled_correctly() -> None:
+    p = PackageURL.from_string(
+        "pkg:nuget/libiconv:%20character%20set%20conversion%20library@1.9?package-id=e11a609df352e292"
+    )
+
+    assert p.type == "nuget"
+    assert p.namespace is None
+    assert p.name == "libiconv: character set conversion library"
+    assert p.version == "1.9"
+    assert p.qualifiers == {"package-id": "e11a609df352e292"}
+    assert p.subpath == None
+
+    assert PackageURL.from_string(p.to_string()).to_string() == p.to_string()
+
+
+def test_colons_in_namespace_are_handled_correctly() -> None:
+    p = PackageURL.from_string(
+        "pkg:nuget/an:odd:space/libiconv:%20character%20set%20conversion%20library@1.9?package-id=e11a609df352e292"
+    )
+
+    assert p.type == "nuget"
+    assert p.namespace == "an:odd:space"
+    assert p.name == "libiconv: character set conversion library"
+    assert p.version == "1.9"
+    assert p.qualifiers == {"package-id": "e11a609df352e292"}
+    assert p.subpath == None
+
+    assert PackageURL.from_string(p.to_string()).to_string() == p.to_string()
+
+
+def test_encoding_stuff_with_colons_correctly() -> None:
+    p = PackageURL(
+        type="nuget",
+        namespace="an:odd:space",
+        name="libiconv: character set conversion library",
+        version="1.9",
+        qualifiers={"package-id": "e11a609df352e292"},
+    )
+    assert (
+        p.to_string()
+        == "pkg:nuget/an:odd:space/libiconv:%20character%20set%20conversion%20library@1.9?package-id=e11a609df352e292"
+    )


### PR DESCRIPTION
This attempts to comply with the specification; at minimum brings it in line with what all the other libraries do.

Closes #152
(I think)

See comment at https://github.com/package-url/packageurl-python/issues/152#issuecomment-2637692538