### PR TITLE
Define `pkg` as a PackageURL class attribute

### DIFF
--- a/src/packageurl/__init__.py
+++ b/src/packageurl/__init__.py
@@ -313,6 +313,7 @@ class PackageURL(
     A purl is a package URL as defined at
     https://github.com/package-url/purl-spec
     """
+
     SCHEME: str = "pkg"
 
     type: str

--- a/src/packageurl/__init__.py
+++ b/src/packageurl/__init__.py
@@ -313,6 +313,7 @@ class PackageURL(
     A purl is a package URL as defined at
     https://github.com/package-url/purl-spec
     """
+    SCHEME: str = "pkg"
 
     type: str
     namespace: str | None
@@ -409,7 +410,7 @@ class PackageURL(
             encode=True,
         )
 
-        purl = ["pkg:", type, "/"]
+        purl = [f"{self.SCHEME}:", type, "/"]
 
         if namespace:
             purl.extend((namespace, "/"))
@@ -440,8 +441,10 @@ class PackageURL(
             raise ValueError("A purl string argument is required.")
 
         scheme, sep, remainder = purl.partition(":")
-        if not sep or scheme != "pkg":
-            raise ValueError(f'purl is missing the required "pkg" scheme component: {purl!r}.')
+        if not sep or scheme != cls.SCHEME:
+            raise ValueError(
+                f'purl is missing the required "{cls.SCHEME}" scheme component: {purl!r}.'
+            )
 
         # this strip '/, // and /// as possible in :// or :///
         remainder = remainder.strip().lstrip("/")


### PR DESCRIPTION
This will allow library users to subclass `PackageURL` and redefine the scheme to create PURL-like derivatives. (e.g. for [the `dep:` idea described here](https://github.com/package-url/purl-spec/issues/386#issuecomment-2636210323)):

```python
class DependencyURL(PackageURL):
    SCHEME = "dep"
```

Which can be used in the same way and happily accepts PEP440-like version ranges in the `version` field 🥳:

```python
>>> dep = DependencyURL.from_string("dep:pypi/requests@>=2.0")
>>> dep
DependencyURL(type='pypi', namespace=None, name='requests', version='>=2.0', qualifiers={}, subpath=None)
```