### PR TITLE
Add `encode` kwarg to `.to_string()`

### DIFF
--- a/src/packageurl/__init__.py
+++ b/src/packageurl/__init__.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import string
 from collections import namedtuple
+from collections.abc import Mapping
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Union
@@ -226,12 +227,12 @@ def normalize_qualifiers(
 
     if not encode:
         return qualifiers_map
-    return _qualifier_map_to_string(qualifiers_map)
+    return _qualifier_map_to_string(qualifiers_map) or None
 
 
 def _qualifier_map_to_string(qualifiers: dict[str, str]) -> str:
     qualifiers_list = [f"{key}={value}" for key, value in qualifiers.items()]
-    return "&".join(qualifiers_list) or None
+    return "&".join(qualifiers_list)
 
 
 def normalize_subpath(subpath: AnyStr | None, encode: bool | None = True) -> str | None:
@@ -428,7 +429,7 @@ class PackageURL(
 
         if qualifiers:
             purl.append("?")
-            if not encode:
+            if isinstance(qualifiers, Mapping):
                 qualifiers = _qualifier_map_to_string(qualifiers)
             purl.append(qualifiers)
 
@@ -436,7 +437,6 @@ class PackageURL(
             purl.append("#")
             purl.append(subpath)
 
-        print(purl)
         return "".join(purl)
 
     @classmethod

--- a/src/packageurl/__init__.py
+++ b/src/packageurl/__init__.py
@@ -226,8 +226,11 @@ def normalize_qualifiers(
 
     if not encode:
         return qualifiers_map
+    return _qualifier_map_to_string(qualifiers_map)
 
-    qualifiers_list = [f"{key}={value}" for key, value in qualifiers_map.items()]
+
+def _qualifier_map_to_string(qualifiers: dict[str, str]) -> str:
+    qualifiers_list = [f"{key}={value}" for key, value in qualifiers.items()]
     return "&".join(qualifiers_list) or None
 
 
@@ -425,12 +428,15 @@ class PackageURL(
 
         if qualifiers:
             purl.append("?")
+            if not encode:
+                qualifiers = _qualifier_map_to_string(qualifiers)
             purl.append(qualifiers)
 
         if subpath:
             purl.append("#")
             purl.append(subpath)
 
+        print(purl)
         return "".join(purl)
 
     @classmethod

--- a/src/packageurl/__init__.py
+++ b/src/packageurl/__init__.py
@@ -398,7 +398,7 @@ class PackageURL(
 
         return data
 
-    def to_string(self) -> str:
+    def to_string(self, encode: bool | None = True) -> str:
         """
         Return a purl string built from components.
         """
@@ -409,7 +409,7 @@ class PackageURL(
             self.version,
             self.qualifiers,
             self.subpath,
-            encode=True,
+            encode=encode,
         )
 
         purl = [self.SCHEME, ":", type, "/"]

--- a/tests/test_packageurl.py
+++ b/tests/test_packageurl.py
@@ -374,3 +374,17 @@ def test_encoding_stuff_with_colons_correctly() -> None:
         p.to_string()
         == "pkg:nuget/an:odd:space/libiconv:%20character%20set%20conversion%20library@1.9?package-id=e11a609df352e292"
     )
+
+
+def test_no_encoding_to_string():
+    p = PackageURL(
+        type="nuget",
+        namespace="an:odd:space",
+        name="libiconv: character set conversion library",
+        version="1.9",
+        qualifiers={"package-id": "e11a609df352e292"},
+    )
+    assert (
+        p.to_string(encode=False)
+        == "pkg:nuget/an:odd:space/libiconv: character set conversion library@1.9?package-id=e11a609df352e292"
+    )


### PR DESCRIPTION
Not sure if this is an acceptable submission, but I found a need to stringify some (simpler) PURL-derivatives and I'd like to have control over the encoding. Mimicking `.to_dict()`'s API, I propose exposing this boolean in `to_string()`.

If you don't like to give this option in that method because you fear people misuse it, may I suggest adding a different one like `to_unencoded_string()` or `to_unsafe_string()` to discourage usage?

Thanks for taking a look!