### PR TITLE
fix: add oci type to url2purl

### DIFF
--- a/src/packageurl/contrib/url2purl.py
+++ b/src/packageurl/contrib/url2purl.py
@@ -728,3 +728,34 @@ def build_generic_google_code_archive_purl(uri):
                 name=name,
                 qualifiers={"download_url": uri},
             )
+
+@purl_router.route(
+    "oci://.*"
+)
+def build_oci_purl(uri):
+    digest = None
+    version_tag = None
+    uri = uri.split("oci://")[1]
+    uri_digest_split = uri.split("@")
+    if len(uri_digest_split) > 1:
+        digest = uri_digest_split[-1]
+        uri = uri_digest_split[0]
+    uri_version_split = uri.split(":")
+    if len(uri_version_split) > 1:
+        version_tag = uri_version_split[-1]
+        if "/" in version_tag:
+            # colon was used to identify port in URL
+            version_tag = None
+        else:
+            uri = uri.split(":" + version_tag)[0]
+    name_repo_split = get_path_segments(uri)
+    name = name_repo_split[-1]
+    repo = uri.split("/" + name)[0]
+    return PackageURL(
+        type="oci",
+        namespace="",
+        name=name,
+        qualifiers={"repository_url": repo, "tag": version_tag},
+        version=digest,
+        subpath="",
+    )

--- a/tests/contrib/data/url2purl.json
+++ b/tests/contrib/data/url2purl.json
@@ -274,5 +274,8 @@
   "": null,
   "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/android-notifier/android-notifier-desktop-0.5.1-1.i386.rpm": "pkg:generic/code.google.com/android-notifier?download_url=https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/android-notifier/android-notifier-desktop-0.5.1-1.i386.rpm",
   "https://cran.r-project.org/src/contrib/jsonlite_1.8.8.tar.gz": "pkg:cran/jsonlite@1.8.8",
-  "https://packagemanager.rstudio.com/cran/2022-06-23/src/contrib/curl_4.3.2.tar.gz": "pkg:cran/curl@4.3.2?download_url=https://packagemanager.rstudio.com/cran/2022-06-23/src/contrib/curl_4.3.2.tar.gz"
+  "https://packagemanager.rstudio.com/cran/2022-06-23/src/contrib/curl_4.3.2.tar.gz": "pkg:cran/curl@4.3.2?download_url=https://packagemanager.rstudio.com/cran/2022-06-23/src/contrib/curl_4.3.2.tar.gz",
+  "oci://localhost:5000/helm-charts/mychart": "pkg:oci/mychart?repository_url=localhost:5000/helm-charts",
+  "oci://registry.relizahub.com/library/rearm-helm:0.0.11": "pkg:oci/rearm-helm?repository_url=registry.relizahub.com/library&tag=0.0.11",
+  "oci://registry.relizahub.com/library/rearm-helm:0.0.11@sha256:0b2de98e6bbd26066fbc1730aa7f8ec8b2cc433235139e4c3bbe0acd8737db4b": "pkg:oci/rearm-helm@sha256:0b2de98e6bbd26066fbc1730aa7f8ec8b2cc433235139e4c3bbe0acd8737db4b?repository_url=registry.relizahub.com/library&tag=0.0.11"
 }


### PR DESCRIPTION
This PR adds oci Purl type to url2purl functionality, allowing to resolve URLs such as **oci://localhost:5000/helm-charts/mychart**.