### PR TITLE
Fix golang purl issue

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+0.17.3 (2025-08-01)
+-------------------
+
+- Add support for getting download URL for Luarocks, Conda, Alpm in ``purl2url``.
+  https://github.com/package-url/packageurl-python/pull/199
+- Fix Incorrect download url from build_golang_download_url()
+  https://github.com/package-url/packageurl-python/issues/198
+
 0.17.2 (2025-07-29)
 -------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = packageurl-python
-version = 0.17.2
+version = 0.17.3
 license = MIT
 description = A purl aka. Package URL parser and builder
 long_description = file:README.rst

--- a/src/packageurl/contrib/purl2url.py
+++ b/src/packageurl/contrib/purl2url.py
@@ -478,6 +478,9 @@ def build_golang_download_url(purl):
     ename = escape_golang_path(name)
     eversion = escape_golang_path(version)
 
+    if not eversion.startswith("v"):
+        eversion = "v" + eversion
+
     if name and version:
         return f"https://proxy.golang.org/{ename}/@v/{eversion}.zip"
 

--- a/tests/contrib/test_purl2url.py
+++ b/tests/contrib/test_purl2url.py
@@ -102,6 +102,7 @@ def test_purl2url_get_download_url():
         "pkg:golang/xorm.io/xorm@v0.8.2": "https://proxy.golang.org/xorm.io/xorm/@v/v0.8.2.zip",
         "pkg:golang/gopkg.in/ldap.v3@v3.1.0": "https://proxy.golang.org/gopkg.in/ldap.v3/@v/v3.1.0.zip",
         "pkg:golang/example.com/M.v3@v3.1.0": "https://proxy.golang.org/example.com/!m.v3/@v/v3.1.0.zip",
+        "pkg:golang/golang.org/x/oauth2@0.29.0": "https://proxy.golang.org/golang.org/x/oauth2/@v/v0.29.0.zip",
         "pkg:pub/http@0.13.3": "https://pub.dev/api/archives/http-0.13.3.tar.gz",
         "pkg:swift/github.com/Alamofire/Alamofire@5.4.3": "https://github.com/Alamofire/Alamofire/archive/5.4.3.zip",
         "pkg:swift/github.com/RxSwiftCommunity/RxFlow@2.12.4": "https://github.com/RxSwiftCommunity/RxFlow/archive/2.12.4.zip",


### PR DESCRIPTION
We shoul add a leading v in version for golang purls download URL where purl's version misses a leading v

- Fixes https://github.com/package-url/packageurl-python/issues/198